### PR TITLE
Store interaction message for timeout handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -131,10 +131,10 @@ async def create_councillor(interaction: discord.Interaction, name: str):
     
     # Create faction selection view
     view = FactionSelectionView(creation_state)
-    
+
     # Send the initial message
-    response = await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
-    creation_state.message = response
+    await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+    creation_state.message = await interaction.original_response()
     
     # Set up timeout
     creation_state.timeout_task = asyncio.create_task(creation_timeout(user_id))


### PR DESCRIPTION
## Summary
- capture the original interaction response in `create_councillor`
- ensure timeout handler edits the stored message when creation times out

## Testing
- `python -m py_compile bot.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689db8aa5df48330a7929da7743a07be